### PR TITLE
Convert Windows Phone 7 projects to Windows Phone 7.1 format and fix Windows Phone 8 build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ Bin
 obj
 packages
 /*.userprefs
+*.sap
+PerfLogs
+UpgradeLog.htm

--- a/AdRotator.sln
+++ b/AdRotator.sln
@@ -1,8 +1,6 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.21005.1
-MinimumVisualStudioVersion = 10.0.40219.1
+# Visual Studio 2012
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Examples", "Examples", "{E2E6A6A8-5342-4850-A86E-6B1E153EBABC}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{971001F2-7071-4A08-9B11-3FB5312EB721}"
@@ -28,13 +26,13 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AdRotator.AdDescriptorCreat
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AdRotator.Examples.Windows8", "Examples\AdRotator.Examples.Windows8\AdRotator.Examples.Windows8.csproj", "{04C0A865-AB86-419B-9D73-6D8BD8BEA3C9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AdRotator.Examples.WinPhone7", "Examples\AdRotator.Examples.WinPhone7\AdRotator.Examples.WinPhone7.csproj", "{210B55C2-AB15-4EAC-A9B6-51A766A40BD0}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AdRotator.Examples.WinPhone8", "Examples\AdRotator.Examples.WinPhone8\AdRotator.Examples.WinPhone8.csproj", "{5E7A5C78-DA60-457F-AEE1-0562BA1DF6AB}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AdRotator.UnitTests", "Tests\AdRotator.UnitTests\AdRotator.UnitTests.csproj", "{A1432A44-A637-4BA2-89BF-B772F39B17AF}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AdRotator.Examples.Windows8.1", "Examples\AdRotator.Examples.Windows8.1\AdRotator.Examples.Windows8.1.csproj", "{635CC4BA-82F2-4E19-9C23-932A159C33AF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AdRotator.Examples.WinPhone7", "Examples\AdRotator.Examples.WinPhone7\AdRotator.Examples.WinPhone7.csproj", "{EAD7641B-EF06-4781-A015-4529EF19DBD7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -70,6 +68,7 @@ Global
 		{170B13CC-30B9-405C-A032-CF1A6B5F8277}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
 		{170B13CC-30B9-405C-A032-CF1A6B5F8277}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{170B13CC-30B9-405C-A032-CF1A6B5F8277}.Debug|Windows Phone.ActiveCfg = Debug|Any CPU
+		{170B13CC-30B9-405C-A032-CF1A6B5F8277}.Debug|Windows Phone.Build.0 = Debug|Any CPU
 		{170B13CC-30B9-405C-A032-CF1A6B5F8277}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{170B13CC-30B9-405C-A032-CF1A6B5F8277}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{170B13CC-30B9-405C-A032-CF1A6B5F8277}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -78,6 +77,7 @@ Global
 		{170B13CC-30B9-405C-A032-CF1A6B5F8277}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{170B13CC-30B9-405C-A032-CF1A6B5F8277}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{170B13CC-30B9-405C-A032-CF1A6B5F8277}.Release|Windows Phone.ActiveCfg = Release|Any CPU
+		{170B13CC-30B9-405C-A032-CF1A6B5F8277}.Release|Windows Phone.Build.0 = Release|Any CPU
 		{170B13CC-30B9-405C-A032-CF1A6B5F8277}.Release|x64.ActiveCfg = Release|Any CPU
 		{170B13CC-30B9-405C-A032-CF1A6B5F8277}.Release|x86.ActiveCfg = Release|Any CPU
 		{31829403-E429-4753-BF39-4CA00C7061E8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -108,6 +108,7 @@ Global
 		{0804BD51-07FF-407B-8CDA-A92039509D1C}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
 		{0804BD51-07FF-407B-8CDA-A92039509D1C}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{0804BD51-07FF-407B-8CDA-A92039509D1C}.Debug|Windows Phone.ActiveCfg = Debug|Any CPU
+		{0804BD51-07FF-407B-8CDA-A92039509D1C}.Debug|Windows Phone.Build.0 = Debug|Any CPU
 		{0804BD51-07FF-407B-8CDA-A92039509D1C}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{0804BD51-07FF-407B-8CDA-A92039509D1C}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{0804BD51-07FF-407B-8CDA-A92039509D1C}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -116,6 +117,7 @@ Global
 		{0804BD51-07FF-407B-8CDA-A92039509D1C}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{0804BD51-07FF-407B-8CDA-A92039509D1C}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{0804BD51-07FF-407B-8CDA-A92039509D1C}.Release|Windows Phone.ActiveCfg = Release|Any CPU
+		{0804BD51-07FF-407B-8CDA-A92039509D1C}.Release|Windows Phone.Build.0 = Release|Any CPU
 		{0804BD51-07FF-407B-8CDA-A92039509D1C}.Release|x64.ActiveCfg = Release|Any CPU
 		{0804BD51-07FF-407B-8CDA-A92039509D1C}.Release|x86.ActiveCfg = Release|Any CPU
 		{7D456892-7A65-4FE7-AA0A-821982FC2E70}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -125,6 +127,7 @@ Global
 		{7D456892-7A65-4FE7-AA0A-821982FC2E70}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
 		{7D456892-7A65-4FE7-AA0A-821982FC2E70}.Debug|Mixed Platforms.Build.0 = Debug|x86
 		{7D456892-7A65-4FE7-AA0A-821982FC2E70}.Debug|Windows Phone.ActiveCfg = Debug|Any CPU
+		{7D456892-7A65-4FE7-AA0A-821982FC2E70}.Debug|Windows Phone.Build.0 = Debug|Any CPU
 		{7D456892-7A65-4FE7-AA0A-821982FC2E70}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{7D456892-7A65-4FE7-AA0A-821982FC2E70}.Debug|x86.ActiveCfg = Debug|x86
 		{7D456892-7A65-4FE7-AA0A-821982FC2E70}.Debug|x86.Build.0 = Debug|x86
@@ -135,6 +138,7 @@ Global
 		{7D456892-7A65-4FE7-AA0A-821982FC2E70}.Release|Mixed Platforms.ActiveCfg = Release|x86
 		{7D456892-7A65-4FE7-AA0A-821982FC2E70}.Release|Mixed Platforms.Build.0 = Release|x86
 		{7D456892-7A65-4FE7-AA0A-821982FC2E70}.Release|Windows Phone.ActiveCfg = Release|Any CPU
+		{7D456892-7A65-4FE7-AA0A-821982FC2E70}.Release|Windows Phone.Build.0 = Release|Any CPU
 		{7D456892-7A65-4FE7-AA0A-821982FC2E70}.Release|x64.ActiveCfg = Release|Any CPU
 		{7D456892-7A65-4FE7-AA0A-821982FC2E70}.Release|x86.ActiveCfg = Release|x86
 		{7D456892-7A65-4FE7-AA0A-821982FC2E70}.Release|x86.Build.0 = Release|x86
@@ -186,26 +190,6 @@ Global
 		{04C0A865-AB86-419B-9D73-6D8BD8BEA3C9}.Release|x86.ActiveCfg = Release|x86
 		{04C0A865-AB86-419B-9D73-6D8BD8BEA3C9}.Release|x86.Build.0 = Release|x86
 		{04C0A865-AB86-419B-9D73-6D8BD8BEA3C9}.Release|x86.Deploy.0 = Release|x86
-		{210B55C2-AB15-4EAC-A9B6-51A766A40BD0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{210B55C2-AB15-4EAC-A9B6-51A766A40BD0}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{210B55C2-AB15-4EAC-A9B6-51A766A40BD0}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
-		{210B55C2-AB15-4EAC-A9B6-51A766A40BD0}.Debug|ARM.ActiveCfg = Debug|Any CPU
-		{210B55C2-AB15-4EAC-A9B6-51A766A40BD0}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
-		{210B55C2-AB15-4EAC-A9B6-51A766A40BD0}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
-		{210B55C2-AB15-4EAC-A9B6-51A766A40BD0}.Debug|Mixed Platforms.Deploy.0 = Debug|Any CPU
-		{210B55C2-AB15-4EAC-A9B6-51A766A40BD0}.Debug|Windows Phone.ActiveCfg = Debug|Any CPU
-		{210B55C2-AB15-4EAC-A9B6-51A766A40BD0}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{210B55C2-AB15-4EAC-A9B6-51A766A40BD0}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{210B55C2-AB15-4EAC-A9B6-51A766A40BD0}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{210B55C2-AB15-4EAC-A9B6-51A766A40BD0}.Release|Any CPU.Build.0 = Release|Any CPU
-		{210B55C2-AB15-4EAC-A9B6-51A766A40BD0}.Release|Any CPU.Deploy.0 = Release|Any CPU
-		{210B55C2-AB15-4EAC-A9B6-51A766A40BD0}.Release|ARM.ActiveCfg = Release|Any CPU
-		{210B55C2-AB15-4EAC-A9B6-51A766A40BD0}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
-		{210B55C2-AB15-4EAC-A9B6-51A766A40BD0}.Release|Mixed Platforms.Build.0 = Release|Any CPU
-		{210B55C2-AB15-4EAC-A9B6-51A766A40BD0}.Release|Mixed Platforms.Deploy.0 = Release|Any CPU
-		{210B55C2-AB15-4EAC-A9B6-51A766A40BD0}.Release|Windows Phone.ActiveCfg = Release|Any CPU
-		{210B55C2-AB15-4EAC-A9B6-51A766A40BD0}.Release|x64.ActiveCfg = Release|Any CPU
-		{210B55C2-AB15-4EAC-A9B6-51A766A40BD0}.Release|x86.ActiveCfg = Release|Any CPU
 		{5E7A5C78-DA60-457F-AEE1-0562BA1DF6AB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{5E7A5C78-DA60-457F-AEE1-0562BA1DF6AB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5E7A5C78-DA60-457F-AEE1-0562BA1DF6AB}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
@@ -216,6 +200,7 @@ Global
 		{5E7A5C78-DA60-457F-AEE1-0562BA1DF6AB}.Debug|Mixed Platforms.Build.0 = Debug|x86
 		{5E7A5C78-DA60-457F-AEE1-0562BA1DF6AB}.Debug|Mixed Platforms.Deploy.0 = Debug|x86
 		{5E7A5C78-DA60-457F-AEE1-0562BA1DF6AB}.Debug|Windows Phone.ActiveCfg = Debug|Any CPU
+		{5E7A5C78-DA60-457F-AEE1-0562BA1DF6AB}.Debug|Windows Phone.Build.0 = Debug|Any CPU
 		{5E7A5C78-DA60-457F-AEE1-0562BA1DF6AB}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{5E7A5C78-DA60-457F-AEE1-0562BA1DF6AB}.Debug|x86.ActiveCfg = Debug|x86
 		{5E7A5C78-DA60-457F-AEE1-0562BA1DF6AB}.Debug|x86.Build.0 = Debug|x86
@@ -226,10 +211,11 @@ Global
 		{5E7A5C78-DA60-457F-AEE1-0562BA1DF6AB}.Release|ARM.ActiveCfg = Release|ARM
 		{5E7A5C78-DA60-457F-AEE1-0562BA1DF6AB}.Release|ARM.Build.0 = Release|ARM
 		{5E7A5C78-DA60-457F-AEE1-0562BA1DF6AB}.Release|ARM.Deploy.0 = Release|ARM
-		{5E7A5C78-DA60-457F-AEE1-0562BA1DF6AB}.Release|Mixed Platforms.ActiveCfg = Release|x86
-		{5E7A5C78-DA60-457F-AEE1-0562BA1DF6AB}.Release|Mixed Platforms.Build.0 = Release|x86
-		{5E7A5C78-DA60-457F-AEE1-0562BA1DF6AB}.Release|Mixed Platforms.Deploy.0 = Release|x86
+		{5E7A5C78-DA60-457F-AEE1-0562BA1DF6AB}.Release|Mixed Platforms.ActiveCfg = Release|ARM
+		{5E7A5C78-DA60-457F-AEE1-0562BA1DF6AB}.Release|Mixed Platforms.Build.0 = Release|ARM
+		{5E7A5C78-DA60-457F-AEE1-0562BA1DF6AB}.Release|Mixed Platforms.Deploy.0 = Release|ARM
 		{5E7A5C78-DA60-457F-AEE1-0562BA1DF6AB}.Release|Windows Phone.ActiveCfg = Release|Any CPU
+		{5E7A5C78-DA60-457F-AEE1-0562BA1DF6AB}.Release|Windows Phone.Build.0 = Release|Any CPU
 		{5E7A5C78-DA60-457F-AEE1-0562BA1DF6AB}.Release|x64.ActiveCfg = Release|Any CPU
 		{5E7A5C78-DA60-457F-AEE1-0562BA1DF6AB}.Release|x86.ActiveCfg = Release|x86
 		{5E7A5C78-DA60-457F-AEE1-0562BA1DF6AB}.Release|x86.Build.0 = Release|x86
@@ -282,15 +268,37 @@ Global
 		{635CC4BA-82F2-4E19-9C23-932A159C33AF}.Release|x86.ActiveCfg = Release|x86
 		{635CC4BA-82F2-4E19-9C23-932A159C33AF}.Release|x86.Build.0 = Release|x86
 		{635CC4BA-82F2-4E19-9C23-932A159C33AF}.Release|x86.Deploy.0 = Release|x86
+		{EAD7641B-EF06-4781-A015-4529EF19DBD7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EAD7641B-EF06-4781-A015-4529EF19DBD7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EAD7641B-EF06-4781-A015-4529EF19DBD7}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
+		{EAD7641B-EF06-4781-A015-4529EF19DBD7}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{EAD7641B-EF06-4781-A015-4529EF19DBD7}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{EAD7641B-EF06-4781-A015-4529EF19DBD7}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{EAD7641B-EF06-4781-A015-4529EF19DBD7}.Debug|Mixed Platforms.Deploy.0 = Debug|Any CPU
+		{EAD7641B-EF06-4781-A015-4529EF19DBD7}.Debug|Windows Phone.ActiveCfg = Debug|Any CPU
+		{EAD7641B-EF06-4781-A015-4529EF19DBD7}.Debug|Windows Phone.Build.0 = Debug|Any CPU
+		{EAD7641B-EF06-4781-A015-4529EF19DBD7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{EAD7641B-EF06-4781-A015-4529EF19DBD7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{EAD7641B-EF06-4781-A015-4529EF19DBD7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EAD7641B-EF06-4781-A015-4529EF19DBD7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EAD7641B-EF06-4781-A015-4529EF19DBD7}.Release|Any CPU.Deploy.0 = Release|Any CPU
+		{EAD7641B-EF06-4781-A015-4529EF19DBD7}.Release|ARM.ActiveCfg = Release|Any CPU
+		{EAD7641B-EF06-4781-A015-4529EF19DBD7}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{EAD7641B-EF06-4781-A015-4529EF19DBD7}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{EAD7641B-EF06-4781-A015-4529EF19DBD7}.Release|Mixed Platforms.Deploy.0 = Release|Any CPU
+		{EAD7641B-EF06-4781-A015-4529EF19DBD7}.Release|Windows Phone.ActiveCfg = Release|Any CPU
+		{EAD7641B-EF06-4781-A015-4529EF19DBD7}.Release|Windows Phone.Build.0 = Release|Any CPU
+		{EAD7641B-EF06-4781-A015-4529EF19DBD7}.Release|x64.ActiveCfg = Release|Any CPU
+		{EAD7641B-EF06-4781-A015-4529EF19DBD7}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{04C0A865-AB86-419B-9D73-6D8BD8BEA3C9} = {E2E6A6A8-5342-4850-A86E-6B1E153EBABC}
-		{210B55C2-AB15-4EAC-A9B6-51A766A40BD0} = {E2E6A6A8-5342-4850-A86E-6B1E153EBABC}
 		{5E7A5C78-DA60-457F-AEE1-0562BA1DF6AB} = {E2E6A6A8-5342-4850-A86E-6B1E153EBABC}
 		{635CC4BA-82F2-4E19-9C23-932A159C33AF} = {E2E6A6A8-5342-4850-A86E-6B1E153EBABC}
+		{EAD7641B-EF06-4781-A015-4529EF19DBD7} = {E2E6A6A8-5342-4850-A86E-6B1E153EBABC}
 		{A1432A44-A637-4BA2-89BF-B772F39B17AF} = {4ABF1E81-6B70-40B3-AB38-D69597B69192}
 	EndGlobalSection
 EndGlobal

--- a/AdRotator/Clients/WinPhone7/AdRotator.WinPhone7.csproj
+++ b/AdRotator/Clients/WinPhone7/AdRotator.WinPhone7.csproj
@@ -11,38 +11,21 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AdRotator</RootNamespace>
     <AssemblyName>AdRotator</AssemblyName>
-    <TargetFrameworkVersion>v8.0</TargetFrameworkVersion>
-    <SilverlightVersion>
-    </SilverlightVersion>
-    <TargetFrameworkProfile>
-    </TargetFrameworkProfile>
-    <TargetFrameworkIdentifier>WindowsPhone</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <SilverlightVersion>$(TargetFrameworkVersion)</SilverlightVersion>
+    <TargetFrameworkProfile>WindowsPhone71</TargetFrameworkProfile>
     <SilverlightApplication>false</SilverlightApplication>
-    <ValidateXaml>true</ValidateXaml>
+    <SupportedCultures>
+    </SupportedCultures>
     <ThrowErrorsInValidation>true</ThrowErrorsInValidation>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
-    <FileUpgradeFlags>
-    </FileUpgradeFlags>
-    <UpgradeBackupLocation>
-    </UpgradeBackupLocation>
-    <OldToolsVersion>4.0</OldToolsVersion>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
-    <PublishUrl>publish\</PublishUrl>
-    <Install>true</Install>
-    <InstallFrom>Disk</InstallFrom>
-    <UpdateEnabled>false</UpdateEnabled>
-    <UpdateMode>Foreground</UpdateMode>
-    <UpdateInterval>7</UpdateInterval>
-    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
-    <UpdatePeriodically>false</UpdatePeriodically>
-    <UpdateRequired>false</UpdateRequired>
-    <MapFileExtensions>true</MapFileExtensions>
-    <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
-    <IsWebBootstrapper>false</IsWebBootstrapper>
-    <UseApplicationTrust>false</UseApplicationTrust>
-    <BootstrapperEnabled>true</BootstrapperEnabled>
+    <ValidateXaml>true</ValidateXaml>
+    <ThrowErrorsInValidation>true</ThrowErrorsInValidation>
+    <Utf8Output>true</Utf8Output>
+    <ExpressionBlendVersion>4.0.30816.0</ExpressionBlendVersion>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -125,34 +108,39 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1 Client Profile</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
+    <Reference Include="Microsoft.Phone" />
+    <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\packages\Microsoft.Bcl.Async.1.0.165\lib\sl4-windowsphone71\Microsoft.Threading.Tasks.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\packages\Microsoft.Bcl.Async.1.0.165\lib\sl4-windowsphone71\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions.Phone, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\packages\Microsoft.Bcl.Async.1.0.165\lib\sl4-windowsphone71\Microsoft.Threading.Tasks.Extensions.Phone.dll</HintPath>
+    </Reference>
+    <Reference Include="mscorlib.Extensions" />
+    <Reference Include="System.Runtime">
+      <HintPath>..\..\..\packages\Microsoft.Bcl.1.0.19\lib\sl4-windowsphone71\System.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks">
+      <HintPath>..\..\..\packages\Microsoft.Bcl.1.0.19\lib\sl4-windowsphone71\System.Threading.Tasks.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Windows" />
+    <Reference Include="system" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup>
-    <Reference Include="Microsoft.Threading.Tasks">
-      <HintPath>..\..\..\packages\Microsoft.Bcl.Async.1.0.165\lib\wp8\Microsoft.Threading.Tasks.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Threading.Tasks.Extensions">
-      <HintPath>..\..\..\packages\Microsoft.Bcl.Async.1.0.165\lib\wp8\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Threading.Tasks.Extensions.Phone">
-      <HintPath>..\..\..\packages\Microsoft.Bcl.Async.1.0.165\lib\wp8\Microsoft.Threading.Tasks.Extensions.Phone.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-  <Import Project="$(MSBuildExtensionsPath)\Microsoft\$(TargetFrameworkIdentifier)\$(TargetFrameworkVersion)\Microsoft.$(TargetFrameworkIdentifier).$(TargetFrameworkVersion).Overrides.targets" />
-  <Import Project="$(MSBuildExtensionsPath)\Microsoft\$(TargetFrameworkIdentifier)\$(TargetFrameworkVersion)\Microsoft.$(TargetFrameworkIdentifier).CSharp.targets" />
+  <Import Project="$(MSBuildExtensionsPath)\Microsoft\Silverlight for Phone\$(TargetFrameworkVersion)\Microsoft.Silverlight.$(TargetFrameworkProfile).Overrides.targets" />
+  <Import Project="$(MSBuildExtensionsPath)\Microsoft\Silverlight for Phone\$(TargetFrameworkVersion)\Microsoft.Silverlight.CSharp.targets" />
   <ProjectExtensions />
+  <Import Project="$(MSBuildExtensionsPath)\Microsoft\Expression\Blend\WindowsPhone\v7.1\Microsoft.Expression.Blend.WindowsPhone.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Import Project="..\..\..\packages\Microsoft.Bcl.Build.1.0.13\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\..\packages\Microsoft.Bcl.Build.1.0.13\tools\Microsoft.Bcl.Build.targets')" />
   <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">

--- a/AdRotator/Clients/WinPhone7/packages.config
+++ b/AdRotator/Clients/WinPhone7/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Bcl" version="1.0.19" targetFramework="wp80" />
-  <package id="Microsoft.Bcl.Async" version="1.0.165" targetFramework="wp80" />
-  <package id="Microsoft.Bcl.Build" version="1.0.13" targetFramework="wp80" />
+  <package id="Microsoft.Bcl" version="1.0.19" targetFramework="wp71" />
+  <package id="Microsoft.Bcl.Async" version="1.0.165" targetFramework="wp71" />
+  <package id="Microsoft.Bcl.Build" version="1.0.13" targetFramework="wp71" />
 </packages>

--- a/Examples/AdRotator.Examples.WinPhone7/AdRotator.Examples.WinPhone7.csproj
+++ b/Examples/AdRotator.Examples.WinPhone7/AdRotator.Examples.WinPhone7.csproj
@@ -1,55 +1,32 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProductVersion>10.0.20506</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{210B55C2-AB15-4EAC-A9B6-51A766A40BD0}</ProjectGuid>
+    <ProjectGuid>{EAD7641B-EF06-4781-A015-4529EF19DBD7}</ProjectGuid>
     <ProjectTypeGuids>{C089C8C0-30E0-4E22-80C0-CE093F111A43};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AdRotator.Examples.WinPhone7</RootNamespace>
     <AssemblyName>AdRotator.Examples.WinPhone7</AssemblyName>
-    <TargetFrameworkVersion>v8.0</TargetFrameworkVersion>
-    <SilverlightVersion>
-    </SilverlightVersion>
-    <TargetFrameworkProfile>
-    </TargetFrameworkProfile>
-    <TargetFrameworkIdentifier>WindowsPhone</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <SilverlightVersion>$(TargetFrameworkVersion)</SilverlightVersion>
+    <TargetFrameworkProfile>WindowsPhone71</TargetFrameworkProfile>
+    <TargetFrameworkIdentifier>Silverlight</TargetFrameworkIdentifier>
     <SilverlightApplication>true</SilverlightApplication>
     <SupportedCultures>
     </SupportedCultures>
     <XapOutputs>true</XapOutputs>
     <GenerateSilverlightManifest>true</GenerateSilverlightManifest>
-    <XapFilename>AdRotator.Examples.WinPhone7_$(Configuration)_$(Platform).xap</XapFilename>
+    <XapFilename>AdRotator.Examples.WinPhone7.xap</XapFilename>
     <SilverlightManifestTemplate>Properties\AppManifest.xml</SilverlightManifestTemplate>
     <SilverlightAppEntry>AdRotator.Examples.WinPhone7.App</SilverlightAppEntry>
     <ValidateXaml>true</ValidateXaml>
     <ThrowErrorsInValidation>true</ThrowErrorsInValidation>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
-    <FileUpgradeFlags>
-    </FileUpgradeFlags>
-    <UpgradeBackupLocation>
-    </UpgradeBackupLocation>
-    <OldToolsVersion>4.0</OldToolsVersion>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
-    <PublishUrl>publish\</PublishUrl>
-    <Install>true</Install>
-    <InstallFrom>Disk</InstallFrom>
-    <UpdateEnabled>false</UpdateEnabled>
-    <UpdateMode>Foreground</UpdateMode>
-    <UpdateInterval>7</UpdateInterval>
-    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
-    <UpdatePeriodically>false</UpdatePeriodically>
-    <UpdateRequired>false</UpdateRequired>
-    <MapFileExtensions>true</MapFileExtensions>
-    <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
-    <IsWebBootstrapper>false</IsWebBootstrapper>
-    <UseApplicationTrust>false</UseApplicationTrust>
-    <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -72,36 +49,12 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
-    <PlatformTarget />
-    <OutputPath>Bin\x86\Debug</OutputPath>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
-    <PlatformTarget />
-    <OutputPath>Bin\x86\Release</OutputPath>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
-    <PlatformTarget />
-    <OutputPath>Bin\ARM\Debug</OutputPath>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM'">
-    <PlatformTarget />
-    <OutputPath>Bin\ARM\Release</OutputPath>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-  </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AdDuplex.WindowsPhone, Version=2.7.0.3, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\AdDuplexWP7.2.7.0.3\lib\sl4-windowsphone71\AdDuplex.WindowsPhone.dll</HintPath>
+    <Reference Include="AdDuplex.WindowsPhone">
+      <HintPath>..\..\packages\AdDuplexWP8.2.8.0.8\lib\sl4-wp71\AdDuplex.WindowsPhone.dll</HintPath>
+    </Reference>
+    <Reference Include="AdRotator.Core">
+      <HintPath>..\..\AdRotator\bin\WindowsPhone7\AdRotator.Core.dll</HintPath>
     </Reference>
     <Reference Include="Google.AdMob.Ads.WindowsPhone7">
       <HintPath>..\..\AdProviderControls\WindowsPhone7\Google.AdMob.Ads.WindowsPhone7.dll</HintPath>
@@ -112,16 +65,16 @@
     <Reference Include="Inneractive.Ad">
       <HintPath>..\..\AdProviderControls\WindowsPhone7\Inneractive.Ad.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Advertising.Mobile, Version=6.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.Advertising.Mobile.UI, Version=6.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.Phone" />
+    <Reference Include="Microsoft.Phone.Interop" />
     <Reference Include="Microsoft.Threading.Tasks">
-      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.165\lib\wp8\Microsoft.Threading.Tasks.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.165\lib\sl4-windowsphone71\Microsoft.Threading.Tasks.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Threading.Tasks.Extensions">
-      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.165\lib\wp8\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.165\lib\sl4-windowsphone71\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Threading.Tasks.Extensions.Phone">
-      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.165\lib\wp8\Microsoft.Threading.Tasks.Extensions.Phone.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.165\lib\sl4-windowsphone71\Microsoft.Threading.Tasks.Extensions.Phone.dll</HintPath>
     </Reference>
     <Reference Include="MobFox.Ads">
       <HintPath>..\..\AdProviderControls\WindowsPhone7\MobFox.Ads.dll</HintPath>
@@ -129,6 +82,18 @@
     <Reference Include="SOMAWP7">
       <HintPath>..\..\AdProviderControls\WindowsPhone7\SOMAWP7.dll</HintPath>
     </Reference>
+    <Reference Include="System.Runtime">
+      <HintPath>..\..\packages\Microsoft.Bcl.1.0.19\lib\sl4-windowsphone71\System.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks">
+      <HintPath>..\..\packages\Microsoft.Bcl.1.0.19\lib\sl4-windowsphone71\System.Threading.Tasks.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Windows" />
+    <Reference Include="system" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Net" />
+    <Reference Include="System.Xml" />
+    <Reference Include="mscorlib.extensions" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="App.xaml.cs">
@@ -143,14 +108,10 @@
     <ApplicationDefinition Include="App.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
     </ApplicationDefinition>
     <Page Include="MainPage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
-      <Generator>MSBuild:Compile</Generator>
-      <SubType>Designer</SubType>
     </Page>
   </ItemGroup>
   <ItemGroup>
@@ -173,29 +134,13 @@
     <Content Include="SplashScreenImage.jpg" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\AdRotator\AdRotator.csproj">
-      <Project>{170B13CC-30B9-405C-A032-CF1A6B5F8277}</Project>
-      <Name>AdRotator</Name>
-    </ProjectReference>
     <ProjectReference Include="..\..\AdRotator\Clients\WinPhone7\AdRotator.WinPhone7.csproj">
       <Project>{0804BD51-07FF-407B-8CDA-A92039509D1C}</Project>
       <Name>AdRotator.WinPhone7</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1 Client Profile</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
-      <Visible>False</Visible>
-      <ProductName>.NET Framework 3.5 SP1</ProductName>
-      <Install>false</Install>
-    </BootstrapperPackage>
-  </ItemGroup>
-  <Import Project="$(MSBuildExtensionsPath)\Microsoft\$(TargetFrameworkIdentifier)\$(TargetFrameworkVersion)\Microsoft.$(TargetFrameworkIdentifier).$(TargetFrameworkVersion).Overrides.targets" />
-  <Import Project="$(MSBuildExtensionsPath)\Microsoft\$(TargetFrameworkIdentifier)\$(TargetFrameworkVersion)\Microsoft.$(TargetFrameworkIdentifier).CSharp.targets" />
+  <Import Project="$(MSBuildExtensionsPath)\Microsoft\Silverlight for Phone\$(TargetFrameworkVersion)\Microsoft.Silverlight.$(TargetFrameworkProfile).Overrides.targets" />
+  <Import Project="$(MSBuildExtensionsPath)\Microsoft\Silverlight for Phone\$(TargetFrameworkVersion)\Microsoft.Silverlight.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Examples/AdRotator.Examples.WinPhone7/App.xaml.cs
+++ b/Examples/AdRotator.Examples.WinPhone7/App.xaml.cs
@@ -1,7 +1,17 @@
-﻿using Microsoft.Phone.Controls;
-using Microsoft.Phone.Shell;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
 using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Animation;
 using System.Windows.Navigation;
+using System.Windows.Shapes;
+using Microsoft.Phone.Controls;
+using Microsoft.Phone.Shell;
 
 namespace AdRotator.Examples.WinPhone7
 {

--- a/Examples/AdRotator.Examples.WinPhone7/MainPage.xaml
+++ b/Examples/AdRotator.Examples.WinPhone7/MainPage.xaml
@@ -12,8 +12,7 @@
     FontSize="{StaticResource PhoneFontSizeNormal}"
     Foreground="{StaticResource PhoneForegroundBrush}"
     SupportedOrientations="Portrait" Orientation="Portrait"
-    shell:SystemTray.IsVisible="True"
-    DataContext="{Binding RelativeSource={RelativeSource Self}}">
+    shell:SystemTray.IsVisible="True">
 
     <!--LayoutRoot is the root grid where all page content is placed-->
     <Grid x:Name="LayoutRoot" Background="Transparent">
@@ -21,6 +20,25 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
+
+        <!-- LOCALIZATION NOTE:
+            To localize the displayed strings copy their values to appropriately named
+            keys in the app's neutral language resource file (AppResources.resx) then
+            replace the hard-coded text value between the attributes' quotation marks
+            with the binding clause whose path points to that string name.
+
+            For example:
+
+                Text="{Binding Path=LocalizedResources.ApplicationTitle, Source={StaticResource LocalizedStrings}}"
+
+            This binding points to the template's string resource named "ApplicationTitle".
+
+            Adding supported languages in the Project Properties tab will create a
+            new resx file per language that can carry the translated values of your
+            UI strings. The binding in these examples will cause the value of the
+            attributes to be drawn from the .resx file that matches the
+            CurrentUICulture of the app at run time.
+         -->
 
         <!--TitlePanel contains the name of the application and page title-->
         <StackPanel x:Name="TitlePanel" Grid.Row="0" Margin="12,17,0,28">
@@ -32,16 +50,27 @@
         <Grid x:Name="ContentPanel" Grid.Row="1" Margin="12,0,12,0">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
             <adRotator:AdRotatorControl x:Name="AdRotatorControl"
                 LocalSettingsLocation="defaultAdSettings.xml"
-                AutoStartAds="True">
-            </adRotator:AdRotatorControl>
-            <ScrollViewer Grid.Row="1">
+                                        AutoStartAds="True"/>
+            <Grid Grid.Row="1" x:Name="ProgramaticAdRotator"/>
+            <Button Grid.Row="2" x:Name="HideButton" Content="Hide/unhide AdRotator" Tap="HideButton_Tap"/>
+            <ScrollViewer Grid.Row="3">
                 <ListBox x:Name="MessagesListBox" Height="Auto"/>
             </ScrollViewer>
         </Grid>
+
+        <!--Uncomment to see an alignment grid to help ensure your controls are
+            aligned on common boundaries.  The image has a top margin of -32px to
+            account for the System Tray. Set this to 0 (or remove the margin altogether)
+            if the System Tray is hidden.
+
+            Before shipping remove this XAML and the image itself.-->
+        <!--<Image Source="/Assets/AlignmentGrid.png" VerticalAlignment="Top" Height="800" Width="480" Margin="0,-32,0,0" Grid.Row="0" Grid.RowSpan="2" IsHitTestVisible="False" />-->
     </Grid>
  
 </phone:PhoneApplicationPage>

--- a/Examples/AdRotator.Examples.WinPhone7/MainPage.xaml.cs
+++ b/Examples/AdRotator.Examples.WinPhone7/MainPage.xaml.cs
@@ -1,27 +1,70 @@
-﻿using Microsoft.Phone.Controls;
+﻿using System.Windows;
+using Microsoft.Phone.Controls;
 
 namespace AdRotator.Examples.WinPhone7
 {
     public partial class MainPage : PhoneApplicationPage
     {
+        // Constructor
+        bool _adRotatorHidden = true;
+        AdRotator.AdRotatorControl _myAdControl;
 
         // Constructor
         public MainPage()
         {
             InitializeComponent();
+
+            // Sample code to localize the ApplicationBar
+            //BuildLocalizedApplicationBar();
             this.AdRotatorControl.Log += (s) => AdRotatorControl_Log(s);
             Loaded += MainPage_Loaded;
+            InitialiseAdRotatorProgramatically();
         }
 
         void MainPage_Loaded(object sender, System.Windows.RoutedEventArgs e)
         {
             AdRotatorControl_Log("Page Loaded");
-
+            HideButton_Tap(null, null);
         }
 
         void AdRotatorControl_Log(string message)
         {
             Dispatcher.BeginInvoke(() => MessagesListBox.Items.Insert(0, message));
         }
+
+        private void HideButton_Tap(object sender, System.Windows.Input.GestureEventArgs e)
+        {
+            _adRotatorHidden = !_adRotatorHidden;
+            AdRotatorControl.Visibility = _adRotatorHidden ? Visibility.Collapsed : Visibility.Visible;
+            HideButton.Content = _adRotatorHidden ? "UnHide AdRotator" : "Hide AdRotator";
+
+        }
+
+        void InitialiseAdRotatorProgramatically()
+        {
+            _myAdControl = new AdRotatorControl();
+            //myAdControl.LocalSettingsLocation = "defaultAdSettings.xml";
+            _myAdControl.RemoteSettingsLocation = "http://adrotator.apphb.com/V2defaultAdSettings.xml";
+            _myAdControl.AdWidth = 728;
+            _myAdControl.AdHeight = 90;
+            _myAdControl.AutoStartAds = true;
+            ProgramaticAdRotator.Children.Add(_myAdControl);
+        }
+
+        // Sample code for building a localized ApplicationBar
+        //private void BuildLocalizedApplicationBar()
+        //{
+        //    // Set the page's ApplicationBar to a new instance of ApplicationBar.
+        //    ApplicationBar = new ApplicationBar();
+
+        //    // Create a new button and set the text value to the localized string from AppResources.
+        //    ApplicationBarIconButton appBarButton = new ApplicationBarIconButton(new Uri("/Assets/AppBar/appbar.add.rest.png", UriKind.Relative));
+        //    appBarButton.Text = AppResources.AppBarButtonText;
+        //    ApplicationBar.Buttons.Add(appBarButton);
+
+        //    // Create a new menu item with the localized string from AppResources.
+        //    ApplicationBarMenuItem appBarMenuItem = new ApplicationBarMenuItem(AppResources.AppBarMenuItemText);
+        //    ApplicationBar.MenuItems.Add(appBarMenuItem);
+        //}
     }
 }

--- a/Examples/AdRotator.Examples.WinPhone7/Properties/AssemblyInfo.cs
+++ b/Examples/AdRotator.Examples.WinPhone7/Properties/AssemblyInfo.cs
@@ -1,6 +1,7 @@
 ﻿using System.Reflection;
-using System.Resources;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Resources;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -10,7 +11,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("AdRotator.Examples.WinPhone7")]
-[assembly: AssemblyCopyright("Copyright ©  2013")]
+[assembly: AssemblyCopyright("Copyright ©  2014")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -20,7 +21,7 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("2290085d-2118-4657-ab10-bd8b9faee9f7")]
+[assembly: Guid("559ec7e5-36af-4b28-b48e-1494a7298722")]
 
 // Version information for an assembly consists of the following four values:
 //

--- a/Examples/AdRotator.Examples.WinPhone7/Properties/WMAppManifest.xml
+++ b/Examples/AdRotator.Examples.WinPhone7/Properties/WMAppManifest.xml
@@ -1,48 +1,28 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Deployment xmlns="http://schemas.microsoft.com/windowsphone/2012/deployment" AppPlatformVersion="8.0">
-  <DefaultLanguage xmlns="" code="" />
-  <App xmlns="" ProductID="{d7d69d99-93b6-4178-baee-df6f0934631f}" Title="AdRotator.Examples.WinPhone7" RuntimeType="Silverlight" Version="1.0.0.0" Genre="apps.normal" Author="AdRotator.Examples.WinPhone7 author" Description="Sample description" Publisher="AdRotator.Examples.WinPhone7" PublisherID="{589b1ffe-441e-47ae-9b04-2905cf1469fa}">
+<Deployment xmlns="http://schemas.microsoft.com/windowsphone/2009/deployment" AppPlatformVersion="7.1">
+  <App xmlns="" ProductID="{ead7641b-ef06-4781-a015-4529ef19dbd7}" Title="AdRotator.Examples.WinPhone7" RuntimeType="Silverlight" Version="1.0.0.0" Genre="apps.normal" Author="AdRotator.Examples.WinPhone7 author" Description="Sample description" Publisher="AdRotator.Examples.WinPhone7">
     <IconPath IsRelative="true" IsResource="false">ApplicationIcon.png</IconPath>
     <Capabilities>
-      <Capability Name="ID_CAP_GAMERSERVICES" />
-      <Capability Name="ID_CAP_IDENTITY_DEVICE" />
-      <Capability Name="ID_CAP_IDENTITY_USER" />
       <Capability Name="ID_CAP_LOCATION" />
-      <Capability Name="ID_CAP_MICROPHONE" />
+      <Capability Name="ID_CAP_MEDIALIB" />
       <Capability Name="ID_CAP_NETWORKING" />
       <Capability Name="ID_CAP_PHONEDIALER" />
-      <Capability Name="ID_CAP_PUSH_NOTIFICATION" />
       <Capability Name="ID_CAP_SENSORS" />
       <Capability Name="ID_CAP_WEBBROWSERCOMPONENT" />
-      <Capability Name="ID_CAP_ISV_CAMERA" />
-      <Capability Name="ID_CAP_CONTACTS" />
-      <Capability Name="ID_CAP_APPOINTMENTS" />
-      <Capability Name="ID_CAP_MEDIALIB_AUDIO" />
-      <Capability Name="ID_CAP_MEDIALIB_PHOTO" />
-      <Capability Name="ID_CAP_MEDIALIB_PLAYBACK" />
+      <Capability Name="ID_CAP_IDENTITY_DEVICE" />
+      <Capability Name="ID_CAP_IDENTITY_USER" />
     </Capabilities>
     <Tasks>
       <DefaultTask Name="_default" NavigationPage="MainPage.xaml" />
     </Tasks>
     <Tokens>
       <PrimaryToken TokenID="AdRotator.Examples.WinPhone7Token" TaskName="_default">
-        <TemplateFlip>
-          <SmallImageURI IsResource="false" IsRelative="true">Background.png</SmallImageURI>
+        <TemplateType5>
+          <BackgroundImageURI IsRelative="true" IsResource="false">Background.png</BackgroundImageURI>
           <Count>0</Count>
-          <BackgroundImageURI IsResource="false" IsRelative="true">Background.png</BackgroundImageURI>
           <Title>AdRotator.Examples.WinPhone7</Title>
-          <BackContent></BackContent>
-          <BackBackgroundImageURI></BackBackgroundImageURI>
-          <BackTitle></BackTitle>
-          <DeviceLockImageURI></DeviceLockImageURI>
-          <HasLarge>false</HasLarge>
-        </TemplateFlip>
+        </TemplateType5>
       </PrimaryToken>
     </Tokens>
-    <ScreenResolutions>
-      <ScreenResolution Name="ID_RESOLUTION_WVGA" />
-      <ScreenResolution Name="ID_RESOLUTION_WXGA" />
-      <ScreenResolution Name="ID_RESOLUTION_HD720P" />
-    </ScreenResolutions>
   </App>
 </Deployment>

--- a/Examples/AdRotator.Examples.WinPhone7/packages.config
+++ b/Examples/AdRotator.Examples.WinPhone7/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AdDuplexWP7" version="2.7.0.3" targetFramework="wp71" />
-  <package id="Microsoft.Bcl" version="1.0.19" targetFramework="wp80" />
-  <package id="Microsoft.Bcl.Async" version="1.0.165" targetFramework="wp80" />
-  <package id="Microsoft.Bcl.Build" version="1.0.13" targetFramework="wp80" />
+  <package id="AdDuplexWP8" version="2.8.0.8" targetFramework="wp71" />
+  <package id="Microsoft.Bcl" version="1.0.19" targetFramework="wp71" />
+  <package id="Microsoft.Bcl.Async" version="1.0.165" targetFramework="wp71" />
+  <package id="Microsoft.Bcl.Build" version="1.0.13" targetFramework="wp71" />
 </packages>

--- a/Examples/AdRotator.Examples.WinPhone8/AdRotator.Examples.WinPhone8.csproj
+++ b/Examples/AdRotator.Examples.WinPhone8/AdRotator.Examples.WinPhone8.csproj
@@ -158,6 +158,9 @@
     <Reference Include="AdDuplex.WindowsPhone">
       <HintPath>..\..\packages\AdDuplexWP8.2.8.0.4\lib\wp8\AdDuplex.WindowsPhone.dll</HintPath>
     </Reference>
+    <Reference Include="Google.AdMob.Ads.WindowsPhone7">
+      <HintPath>..\..\AdProviderControls\WindowsPhone8\Google.AdMob.Ads.WindowsPhone7.dll</HintPath>
+    </Reference>
     <Reference Include="InMobiWPAdSDK">
       <HintPath>..\..\AdProviderControls\WindowsPhone8\InMobiWPAdSDK.dll</HintPath>
     </Reference>
@@ -178,9 +181,6 @@
     </Reference>
     <Reference Include="SOMAWP8">
       <HintPath>..\..\AdProviderControls\WindowsPhone8\SOMAWP8.dll</HintPath>
-    </Reference>
-    <Reference Include="GoogleAds">
-      <HintPath>..\..\AdProviderControls\WindowsPhone8\GoogleAds.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Examples/AdRotator.Examples.WinPhone8/Properties/WMAppManifest.xml
+++ b/Examples/AdRotator.Examples.WinPhone8/Properties/WMAppManifest.xml
@@ -5,29 +5,16 @@
     <IconPath IsRelative="true" IsResource="false">Assets\ApplicationIcon.png</IconPath>
     <Capabilities>
       <Capability Name="ID_CAP_NETWORKING" />
+      <Capability Name="ID_CAP_WEBBROWSERCOMPONENT" />
+      <Capability Name="ID_CAP_MAP" />
+      <Capability Name="ID_CAP_IDENTITY_USER" />
+      <Capability Name="ID_CAP_MEDIALIB_PHOTO" />
+      <Capability Name="ID_CAP_PHONEDIALER" />
+      <Capability Name="ID_CAP_IDENTITY_DEVICE" />
+      <Capability Name="ID_CAP_MEDIALIB_AUDIO" />
       <Capability Name="ID_CAP_MEDIALIB_PLAYBACK" />
       <Capability Name="ID_CAP_SENSORS" />
-      <Capability Name="ID_CAP_WEBBROWSERCOMPONENT" />
       <Capability Name="ID_CAP_LOCATION" />
-      <Capability Name="ID_CAP_APPOINTMENTS" />
-      <Capability Name="ID_CAP_CONTACTS" />
-      <Capability Name="ID_CAP_GAMERSERVICES" />
-      <Capability Name="ID_CAP_IDENTITY_DEVICE" />
-      <Capability Name="ID_CAP_IDENTITY_USER" />
-      <Capability Name="ID_CAP_ISV_CAMERA" />
-      <Capability Name="ID_CAP_MAP" />
-      <Capability Name="ID_CAP_MEDIALIB_PHOTO" />
-      <Capability Name="ID_CAP_MEDIALIB_AUDIO" />
-      <Capability Name="ID_CAP_MICROPHONE" />
-      <Capability Name="ID_CAP_PHONEDIALER" />
-      <Capability Name="ID_CAP_PROXIMITY" />
-      <Capability Name="ID_CAP_PUSH_NOTIFICATION" />
-      <Capability Name="ID_CAP_REMOVABLE_STORAGE" />
-      <Capability Name="ID_CAP_SPEECH_RECOGNITION" />
-      <Capability Name="ID_CAP_VOIP" />
-      <Capability Name="ID_CAP_WALLET" />
-      <Capability Name="ID_CAP_WALLET_PAYMENTINSTRUMENTS" />
-      <Capability Name="ID_CAP_WALLET_SECUREELEMENT" />
     </Capabilities>
     <Tasks>
       <DefaultTask Name="_default" NavigationPage="MainPage.xaml" />

--- a/Tests/AdRotator.UnitTests/AdRotator.UnitTests.csproj
+++ b/Tests/AdRotator.UnitTests/AdRotator.UnitTests.csproj
@@ -96,6 +96,11 @@
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
+  <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.13\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.13\tools\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
+    <Error Condition="!Exists('..\..\packages\Microsoft.Bcl.Build.1.0.13\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
+    <Error Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.13\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Tests/AdRotator.UnitTests/packages.config
+++ b/Tests/AdRotator.UnitTests/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Bcl.Build" version="1.0.13" targetFramework="net45" />
   <package id="Moq" version="4.2.1312.1622" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
The projects for the WinPhone7 Client and AdRotator.Examples.WinPhone7 were both set up as Windows Phone 8 apps, these commits change the format of the project to target Silverlight on WP7 and update the NuGet references to point to their WP7 counterparts.

Furthermore the Windows Phone 8 project referenced a missing GoogleAds.dll this has been corrected to reference Google.AdMob.Ads.WindowsPhone7.dll which is present in the WindowsPhone8 libraries folder.

The set of Capabilities defined in the Windows Phone 8 WMAppManifest had selected all capabilities which caused the app to quit at the splash screen, this pull request also sets the capabilities to the set that is required to run the application.
