### PR TITLE
Fix design time error "Unable to determine application identity of the caller"

### DIFF
--- a/AdRotator/AdRotatorControl.xaml.cs
+++ b/AdRotator/AdRotatorControl.xaml.cs
@@ -21,9 +21,9 @@ namespace AdRotator
                 Log(message);
             }
         }
-        #endregion 
+        #endregion
 
-        private AdRotatorComponent adRotatorControl = new AdRotatorComponent(Thread.CurrentThread.CurrentUICulture.ToString(), new FileHelpers());
+        private AdRotatorComponent adRotatorControl;
 #if WINPHONE7
         AdRotator.AdProviderConfig.SupportedPlatforms CurrentPlatform = AdRotator.AdProviderConfig.SupportedPlatforms.WindowsPhone7;
 #else
@@ -33,6 +33,7 @@ namespace AdRotator
         public AdRotatorControl()
         {
             InitializeComponent();
+            adRotatorControl = new AdRotatorComponent(Thread.CurrentThread.CurrentUICulture.ToString(), IsInDesignMode ? null : new FileHelpers());
             Loaded += AdRotatorControl_Loaded;
 
             // List of AdProviders supportd on this platform


### PR DESCRIPTION
As IsolatedStorage methods are used in the FileHelpers class, this can't be used at design time, initialise the AdRotatorComponent field on AdRotatorControl in the constructor and pass in null for the FileHelpers argument, this fixes displaying the control at design time.
